### PR TITLE
Doubled OCR-D-IMG-BIN-OCROPY entry

### DIFF
--- a/conf/workflow_configuration.txt
+++ b/conf/workflow_configuration.txt
@@ -24,7 +24,7 @@
 # Example:
 # ocrd-kraken-binarize|OCR-D-IMG|OCR-D-IMG-BIN-KRAKEN| |https://host/ocr-kraken-binarize-params.json|ERROR
 ########################################################################
-ocrd-cis-ocropy-binarize      | OCR-D-IMG            | OCR-D-IMG-BIN-OCROPY,OCR-D-IMG-BIN-OCROPY | | |ERROR
+ocrd-cis-ocropy-binarize      | OCR-D-IMG            | OCR-D-IMG-BIN-OCROPY | | |ERROR
 ocrd-tesserocr-segment-region | OCR-D-IMG-BIN-OCROPY | OCR-D-SEG-REGION               | | |ERROR
 ocrd-tesserocr-segment-line   | OCR-D-SEG-REGION     | OCR-D-SEG-LINE                 | | |ERROR
 ocrd-tesserocr-recognize      | OCR-D-SEG-LINE       | OCR-D-OCR-TESSEROCR-FRAKTUR    | | {\"textequiv_level\":\"glyph\",\"overwrite_words\":true,\"model\":\"Fraktur\"} |ERROR


### PR DESCRIPTION
Produces error: Step #1 ocrd-cis-ocropy-binarize - already existing output file group 'OCR-D-IMG-BIN-OCROPY'